### PR TITLE
Fixing: PFWORKBIN-302 and PFWORKBIN-445

### DIFF
--- a/PlayFabClientSDK/PlayFabSDK/include/playfab/PlayFabClientDataModels.h
+++ b/PlayFabClientSDK/PlayFabSDK/include/playfab/PlayFabClientDataModels.h
@@ -1188,14 +1188,14 @@ namespace ClientModels
 	struct CurrentGamesRequest : public PlayFabBaseModel
     {
 		
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::string BuildVersion;
 		std::string GameMode;
 		std::string StatisticName;
 	
         CurrentGamesRequest() :
 			PlayFabBaseModel(),
-			Region(),
+			pfRegion(),
 			BuildVersion(),
 			GameMode(),
 			StatisticName()
@@ -1203,7 +1203,7 @@ namespace ClientModels
 		
 		CurrentGamesRequest(const CurrentGamesRequest& src) :
 			PlayFabBaseModel(),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			BuildVersion(src.BuildVersion),
 			GameMode(src.GameMode),
 			StatisticName(src.StatisticName)
@@ -1223,7 +1223,7 @@ namespace ClientModels
 	struct GameInfo : public PlayFabBaseModel
     {
 		
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::string LobbyID;
 		std::string BuildVersion;
 		std::string GameMode;
@@ -1235,7 +1235,7 @@ namespace ClientModels
 	
         GameInfo() :
 			PlayFabBaseModel(),
-			Region(),
+			pfRegion(),
 			LobbyID(),
 			BuildVersion(),
 			GameMode(),
@@ -1248,7 +1248,7 @@ namespace ClientModels
 		
 		GameInfo(const GameInfo& src) :
 			PlayFabBaseModel(),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			LobbyID(src.LobbyID),
 			BuildVersion(src.BuildVersion),
 			GameMode(src.GameMode),
@@ -1565,14 +1565,14 @@ namespace ClientModels
 	struct RegionInfo : public PlayFabBaseModel
     {
 		
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::string Name;
 		bool Available;
 		std::string PingUrl;
 	
         RegionInfo() :
 			PlayFabBaseModel(),
-			Region(),
+			pfRegion(),
 			Name(),
 			Available(false),
 			PingUrl()
@@ -1580,7 +1580,7 @@ namespace ClientModels
 		
 		RegionInfo(const RegionInfo& src) :
 			PlayFabBaseModel(),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			Name(src.Name),
 			Available(src.Available),
 			PingUrl(src.PingUrl)
@@ -4828,7 +4828,7 @@ namespace ClientModels
     {
 		
 		std::string BuildVersion;
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::string GameMode;
 		std::string LobbyId;
 		std::string StatisticName;
@@ -4838,7 +4838,7 @@ namespace ClientModels
         MatchmakeRequest() :
 			PlayFabBaseModel(),
 			BuildVersion(),
-			Region(),
+			pfRegion(),
 			GameMode(),
 			LobbyId(),
 			StatisticName(),
@@ -4849,7 +4849,7 @@ namespace ClientModels
 		MatchmakeRequest(const MatchmakeRequest& src) :
 			PlayFabBaseModel(),
 			BuildVersion(src.BuildVersion),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			GameMode(src.GameMode),
 			LobbyId(src.LobbyId),
 			StatisticName(src.StatisticName),
@@ -5840,7 +5840,7 @@ namespace ClientModels
     {
 		
 		std::string BuildVersion;
-		Region Region;
+		Region pfRegion;
 		std::string GameMode;
 		std::string StatisticName;
 		std::string CharacterId;
@@ -5849,7 +5849,7 @@ namespace ClientModels
         StartGameRequest() :
 			PlayFabBaseModel(),
 			BuildVersion(),
-			Region(),
+			pfRegion(),
 			GameMode(),
 			StatisticName(),
 			CharacterId(),
@@ -5859,7 +5859,7 @@ namespace ClientModels
 		StartGameRequest(const StartGameRequest& src) :
 			PlayFabBaseModel(),
 			BuildVersion(src.BuildVersion),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			GameMode(src.GameMode),
 			StatisticName(src.StatisticName),
 			CharacterId(src.CharacterId),

--- a/PlayFabClientSDK/PlayFabSDK/source/PlayFabClientDataModels.cpp
+++ b/PlayFabClientSDK/PlayFabSDK/source/PlayFabClientDataModels.cpp
@@ -1869,7 +1869,7 @@ void CurrentGamesRequest::writeJSON(PFStringJsonWriter& writer)
     writer.StartObject();
 
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(BuildVersion.length() > 0) { writer.String("BuildVersion"); writer.String(BuildVersion.c_str()); }
     
@@ -1885,7 +1885,7 @@ bool CurrentGamesRequest::readFromValue(const rapidjson::Value& obj)
 {
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* BuildVersion_member = obj.FindMember("BuildVersion");
 	if (BuildVersion_member != NULL && !BuildVersion_member->value.IsNull()) BuildVersion = BuildVersion_member->value.GetString();
@@ -1911,7 +1911,7 @@ void GameInfo::writeJSON(PFStringJsonWriter& writer)
     writer.StartObject();
 
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(LobbyID.length() > 0) { writer.String("LobbyID"); writer.String(LobbyID.c_str()); }
     
@@ -1944,7 +1944,7 @@ bool GameInfo::readFromValue(const rapidjson::Value& obj)
 {
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* LobbyID_member = obj.FindMember("LobbyID");
 	if (LobbyID_member != NULL && !LobbyID_member->value.IsNull()) LobbyID = LobbyID_member->value.GetString();
@@ -2370,7 +2370,7 @@ void RegionInfo::writeJSON(PFStringJsonWriter& writer)
     writer.StartObject();
 
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(Name.length() > 0) { writer.String("Name"); writer.String(Name.c_str()); }
     
@@ -2386,7 +2386,7 @@ bool RegionInfo::readFromValue(const rapidjson::Value& obj)
 {
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* Name_member = obj.FindMember("Name");
 	if (Name_member != NULL && !Name_member->value.IsNull()) Name = Name_member->value.GetString();
@@ -6654,7 +6654,7 @@ void MatchmakeRequest::writeJSON(PFStringJsonWriter& writer)
     
     if(BuildVersion.length() > 0) { writer.String("BuildVersion"); writer.String(BuildVersion.c_str()); }
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(GameMode.length() > 0) { writer.String("GameMode"); writer.String(GameMode.c_str()); }
     
@@ -6677,7 +6677,7 @@ bool MatchmakeRequest::readFromValue(const rapidjson::Value& obj)
 	if (BuildVersion_member != NULL && !BuildVersion_member->value.IsNull()) BuildVersion = BuildVersion_member->value.GetString();
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* GameMode_member = obj.FindMember("GameMode");
 	if (GameMode_member != NULL && !GameMode_member->value.IsNull()) GameMode = GameMode_member->value.GetString();
@@ -7970,7 +7970,7 @@ void StartGameRequest::writeJSON(PFStringJsonWriter& writer)
     
     writer.String("BuildVersion"); writer.String(BuildVersion.c_str());
     
-    writer.String("Region"); writeRegionEnumJSON(Region, writer);
+    writer.String("Region"); writeRegionEnumJSON(pfRegion, writer);
     
     writer.String("GameMode"); writer.String(GameMode.c_str());
     
@@ -7991,7 +7991,7 @@ bool StartGameRequest::readFromValue(const rapidjson::Value& obj)
 	if (BuildVersion_member != NULL && !BuildVersion_member->value.IsNull()) BuildVersion = BuildVersion_member->value.GetString();
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* GameMode_member = obj.FindMember("GameMode");
 	if (GameMode_member != NULL && !GameMode_member->value.IsNull()) GameMode = GameMode_member->value.GetString();

--- a/PlayFabClientSDK/PlayFabSDK/source/PlayFabResultHandler.cpp
+++ b/PlayFabClientSDK/PlayFabSDK/source/PlayFabResultHandler.cpp
@@ -38,7 +38,7 @@ bool PlayFabRequestHandler::DecodeRequest(int httpStatus, HttpRequest* request, 
 			outError.HttpCode = 408;
 			outError.ErrorCode = PlayFabErrorConnectionTimeout;
 			// For text returns, use the non-json response if possible, else default to no response
-			outError.ErrorName = outError.ErrorMessage = outError.HttpStatus = response.length() == 0 ? "Request Timeout or null response" : response;
+			outError.ErrorName = outError.ErrorMessage = outError.HttpStatus = response;
 			return false;
 		}
 		// TODO: what happens when the error is not in the enum?

--- a/PlayFabSDK/PlayFabSDK/include/playfab/PlayFabAdminDataModels.h
+++ b/PlayFabSDK/PlayFabSDK/include/playfab/PlayFabAdminDataModels.h
@@ -1222,7 +1222,7 @@ namespace AdminModels
 		OptionalTime EndTime;
 		std::string Mode;
 		std::string BuildVersion;
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::list<std::string> Players;
 		std::string ServerAddress;
 		Uint32 ServerPort;
@@ -1235,7 +1235,7 @@ namespace AdminModels
 			EndTime(),
 			Mode(),
 			BuildVersion(),
-			Region(),
+			pfRegion(),
 			Players(),
 			ServerAddress(),
 			ServerPort(0)
@@ -1249,7 +1249,7 @@ namespace AdminModels
 			EndTime(src.EndTime),
 			Mode(src.Mode),
 			BuildVersion(src.BuildVersion),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			Players(src.Players),
 			ServerAddress(src.ServerAddress),
 			ServerPort(src.ServerPort)

--- a/PlayFabSDK/PlayFabSDK/include/playfab/PlayFabClientDataModels.h
+++ b/PlayFabSDK/PlayFabSDK/include/playfab/PlayFabClientDataModels.h
@@ -1188,14 +1188,14 @@ namespace ClientModels
 	struct CurrentGamesRequest : public PlayFabBaseModel
     {
 		
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::string BuildVersion;
 		std::string GameMode;
 		std::string StatisticName;
 	
         CurrentGamesRequest() :
 			PlayFabBaseModel(),
-			Region(),
+			pfRegion(),
 			BuildVersion(),
 			GameMode(),
 			StatisticName()
@@ -1203,7 +1203,7 @@ namespace ClientModels
 		
 		CurrentGamesRequest(const CurrentGamesRequest& src) :
 			PlayFabBaseModel(),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			BuildVersion(src.BuildVersion),
 			GameMode(src.GameMode),
 			StatisticName(src.StatisticName)
@@ -1223,7 +1223,7 @@ namespace ClientModels
 	struct GameInfo : public PlayFabBaseModel
     {
 		
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::string LobbyID;
 		std::string BuildVersion;
 		std::string GameMode;
@@ -1235,7 +1235,7 @@ namespace ClientModels
 	
         GameInfo() :
 			PlayFabBaseModel(),
-			Region(),
+			pfRegion(),
 			LobbyID(),
 			BuildVersion(),
 			GameMode(),
@@ -1248,7 +1248,7 @@ namespace ClientModels
 		
 		GameInfo(const GameInfo& src) :
 			PlayFabBaseModel(),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			LobbyID(src.LobbyID),
 			BuildVersion(src.BuildVersion),
 			GameMode(src.GameMode),
@@ -1565,14 +1565,14 @@ namespace ClientModels
 	struct RegionInfo : public PlayFabBaseModel
     {
 		
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::string Name;
 		bool Available;
 		std::string PingUrl;
 	
         RegionInfo() :
 			PlayFabBaseModel(),
-			Region(),
+			pfRegion(),
 			Name(),
 			Available(false),
 			PingUrl()
@@ -1580,7 +1580,7 @@ namespace ClientModels
 		
 		RegionInfo(const RegionInfo& src) :
 			PlayFabBaseModel(),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			Name(src.Name),
 			Available(src.Available),
 			PingUrl(src.PingUrl)
@@ -4828,7 +4828,7 @@ namespace ClientModels
     {
 		
 		std::string BuildVersion;
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::string GameMode;
 		std::string LobbyId;
 		std::string StatisticName;
@@ -4838,7 +4838,7 @@ namespace ClientModels
         MatchmakeRequest() :
 			PlayFabBaseModel(),
 			BuildVersion(),
-			Region(),
+			pfRegion(),
 			GameMode(),
 			LobbyId(),
 			StatisticName(),
@@ -4849,7 +4849,7 @@ namespace ClientModels
 		MatchmakeRequest(const MatchmakeRequest& src) :
 			PlayFabBaseModel(),
 			BuildVersion(src.BuildVersion),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			GameMode(src.GameMode),
 			LobbyId(src.LobbyId),
 			StatisticName(src.StatisticName),
@@ -5840,7 +5840,7 @@ namespace ClientModels
     {
 		
 		std::string BuildVersion;
-		Region Region;
+		Region pfRegion;
 		std::string GameMode;
 		std::string StatisticName;
 		std::string CharacterId;
@@ -5849,7 +5849,7 @@ namespace ClientModels
         StartGameRequest() :
 			PlayFabBaseModel(),
 			BuildVersion(),
-			Region(),
+			pfRegion(),
 			GameMode(),
 			StatisticName(),
 			CharacterId(),
@@ -5859,7 +5859,7 @@ namespace ClientModels
 		StartGameRequest(const StartGameRequest& src) :
 			PlayFabBaseModel(),
 			BuildVersion(src.BuildVersion),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			GameMode(src.GameMode),
 			StatisticName(src.StatisticName),
 			CharacterId(src.CharacterId),

--- a/PlayFabSDK/PlayFabSDK/include/playfab/PlayFabMatchmakerDataModels.h
+++ b/PlayFabSDK/PlayFabSDK/include/playfab/PlayFabMatchmakerDataModels.h
@@ -255,7 +255,7 @@ namespace MatchmakerModels
     {
 		
 		std::string Build;
-		Region Region;
+		Region pfRegion;
 		std::string GameMode;
 		std::string CustomCommandLineData;
 		std::string ExternalMatchmakerEventEndpoint;
@@ -263,7 +263,7 @@ namespace MatchmakerModels
         StartGameRequest() :
 			PlayFabBaseModel(),
 			Build(),
-			Region(),
+			pfRegion(),
 			GameMode(),
 			CustomCommandLineData(),
 			ExternalMatchmakerEventEndpoint()
@@ -272,7 +272,7 @@ namespace MatchmakerModels
 		StartGameRequest(const StartGameRequest& src) :
 			PlayFabBaseModel(),
 			Build(src.Build),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			GameMode(src.GameMode),
 			CustomCommandLineData(src.CustomCommandLineData),
 			ExternalMatchmakerEventEndpoint(src.ExternalMatchmakerEventEndpoint)

--- a/PlayFabSDK/PlayFabSDK/source/PlayFabAdminDataModels.cpp
+++ b/PlayFabSDK/PlayFabSDK/source/PlayFabAdminDataModels.cpp
@@ -1807,7 +1807,7 @@ void GetMatchmakerGameInfoResult::writeJSON(PFStringJsonWriter& writer)
     
     if(BuildVersion.length() > 0) { writer.String("BuildVersion"); writer.String(BuildVersion.c_str()); }
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(!Players.empty()) {
 	writer.String("Players");
@@ -1848,7 +1848,7 @@ bool GetMatchmakerGameInfoResult::readFromValue(const rapidjson::Value& obj)
 	if (BuildVersion_member != NULL && !BuildVersion_member->value.IsNull()) BuildVersion = BuildVersion_member->value.GetString();
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* Players_member = obj.FindMember("Players");
 	if (Players_member != NULL) {

--- a/PlayFabSDK/PlayFabSDK/source/PlayFabClientDataModels.cpp
+++ b/PlayFabSDK/PlayFabSDK/source/PlayFabClientDataModels.cpp
@@ -1869,7 +1869,7 @@ void CurrentGamesRequest::writeJSON(PFStringJsonWriter& writer)
     writer.StartObject();
 
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(BuildVersion.length() > 0) { writer.String("BuildVersion"); writer.String(BuildVersion.c_str()); }
     
@@ -1885,7 +1885,7 @@ bool CurrentGamesRequest::readFromValue(const rapidjson::Value& obj)
 {
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* BuildVersion_member = obj.FindMember("BuildVersion");
 	if (BuildVersion_member != NULL && !BuildVersion_member->value.IsNull()) BuildVersion = BuildVersion_member->value.GetString();
@@ -1911,7 +1911,7 @@ void GameInfo::writeJSON(PFStringJsonWriter& writer)
     writer.StartObject();
 
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(LobbyID.length() > 0) { writer.String("LobbyID"); writer.String(LobbyID.c_str()); }
     
@@ -1944,7 +1944,7 @@ bool GameInfo::readFromValue(const rapidjson::Value& obj)
 {
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* LobbyID_member = obj.FindMember("LobbyID");
 	if (LobbyID_member != NULL && !LobbyID_member->value.IsNull()) LobbyID = LobbyID_member->value.GetString();
@@ -2370,7 +2370,7 @@ void RegionInfo::writeJSON(PFStringJsonWriter& writer)
     writer.StartObject();
 
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(Name.length() > 0) { writer.String("Name"); writer.String(Name.c_str()); }
     
@@ -2386,7 +2386,7 @@ bool RegionInfo::readFromValue(const rapidjson::Value& obj)
 {
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* Name_member = obj.FindMember("Name");
 	if (Name_member != NULL && !Name_member->value.IsNull()) Name = Name_member->value.GetString();
@@ -6654,7 +6654,7 @@ void MatchmakeRequest::writeJSON(PFStringJsonWriter& writer)
     
     if(BuildVersion.length() > 0) { writer.String("BuildVersion"); writer.String(BuildVersion.c_str()); }
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(GameMode.length() > 0) { writer.String("GameMode"); writer.String(GameMode.c_str()); }
     
@@ -6677,7 +6677,7 @@ bool MatchmakeRequest::readFromValue(const rapidjson::Value& obj)
 	if (BuildVersion_member != NULL && !BuildVersion_member->value.IsNull()) BuildVersion = BuildVersion_member->value.GetString();
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* GameMode_member = obj.FindMember("GameMode");
 	if (GameMode_member != NULL && !GameMode_member->value.IsNull()) GameMode = GameMode_member->value.GetString();
@@ -7970,7 +7970,7 @@ void StartGameRequest::writeJSON(PFStringJsonWriter& writer)
     
     writer.String("BuildVersion"); writer.String(BuildVersion.c_str());
     
-    writer.String("Region"); writeRegionEnumJSON(Region, writer);
+    writer.String("Region"); writeRegionEnumJSON(pfRegion, writer);
     
     writer.String("GameMode"); writer.String(GameMode.c_str());
     
@@ -7991,7 +7991,7 @@ bool StartGameRequest::readFromValue(const rapidjson::Value& obj)
 	if (BuildVersion_member != NULL && !BuildVersion_member->value.IsNull()) BuildVersion = BuildVersion_member->value.GetString();
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* GameMode_member = obj.FindMember("GameMode");
 	if (GameMode_member != NULL && !GameMode_member->value.IsNull()) GameMode = GameMode_member->value.GetString();

--- a/PlayFabSDK/PlayFabSDK/source/PlayFabMatchmakerDataModels.cpp
+++ b/PlayFabSDK/PlayFabSDK/source/PlayFabMatchmakerDataModels.cpp
@@ -345,7 +345,7 @@ void StartGameRequest::writeJSON(PFStringJsonWriter& writer)
     
     writer.String("Build"); writer.String(Build.c_str());
     
-    writer.String("Region"); writeRegionEnumJSON(Region, writer);
+    writer.String("Region"); writeRegionEnumJSON(pfRegion, writer);
     
     writer.String("GameMode"); writer.String(GameMode.c_str());
     
@@ -364,7 +364,7 @@ bool StartGameRequest::readFromValue(const rapidjson::Value& obj)
 	if (Build_member != NULL && !Build_member->value.IsNull()) Build = Build_member->value.GetString();
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* GameMode_member = obj.FindMember("GameMode");
 	if (GameMode_member != NULL && !GameMode_member->value.IsNull()) GameMode = GameMode_member->value.GetString();

--- a/PlayFabSDK/PlayFabSDK/source/PlayFabResultHandler.cpp
+++ b/PlayFabSDK/PlayFabSDK/source/PlayFabResultHandler.cpp
@@ -38,7 +38,7 @@ bool PlayFabRequestHandler::DecodeRequest(int httpStatus, HttpRequest* request, 
 			outError.HttpCode = 408;
 			outError.ErrorCode = PlayFabErrorConnectionTimeout;
 			// For text returns, use the non-json response if possible, else default to no response
-			outError.ErrorName = outError.ErrorMessage = outError.HttpStatus = response.length() == 0 ? "Request Timeout or null response" : response;
+			outError.ErrorName = outError.ErrorMessage = outError.HttpStatus = response;
 			return false;
 		}
 		// TODO: what happens when the error is not in the enum?

--- a/PlayFabServerSDK/PlayFabSDK/include/playfab/PlayFabAdminDataModels.h
+++ b/PlayFabServerSDK/PlayFabSDK/include/playfab/PlayFabAdminDataModels.h
@@ -1222,7 +1222,7 @@ namespace AdminModels
 		OptionalTime EndTime;
 		std::string Mode;
 		std::string BuildVersion;
-		Boxed<Region> Region;
+		Boxed<Region> pfRegion;
 		std::list<std::string> Players;
 		std::string ServerAddress;
 		Uint32 ServerPort;
@@ -1235,7 +1235,7 @@ namespace AdminModels
 			EndTime(),
 			Mode(),
 			BuildVersion(),
-			Region(),
+			pfRegion(),
 			Players(),
 			ServerAddress(),
 			ServerPort(0)
@@ -1249,7 +1249,7 @@ namespace AdminModels
 			EndTime(src.EndTime),
 			Mode(src.Mode),
 			BuildVersion(src.BuildVersion),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			Players(src.Players),
 			ServerAddress(src.ServerAddress),
 			ServerPort(src.ServerPort)

--- a/PlayFabServerSDK/PlayFabSDK/include/playfab/PlayFabMatchmakerDataModels.h
+++ b/PlayFabServerSDK/PlayFabSDK/include/playfab/PlayFabMatchmakerDataModels.h
@@ -255,7 +255,7 @@ namespace MatchmakerModels
     {
 		
 		std::string Build;
-		Region Region;
+		Region pfRegion;
 		std::string GameMode;
 		std::string CustomCommandLineData;
 		std::string ExternalMatchmakerEventEndpoint;
@@ -263,7 +263,7 @@ namespace MatchmakerModels
         StartGameRequest() :
 			PlayFabBaseModel(),
 			Build(),
-			Region(),
+			pfRegion(),
 			GameMode(),
 			CustomCommandLineData(),
 			ExternalMatchmakerEventEndpoint()
@@ -272,7 +272,7 @@ namespace MatchmakerModels
 		StartGameRequest(const StartGameRequest& src) :
 			PlayFabBaseModel(),
 			Build(src.Build),
-			Region(src.Region),
+			pfRegion(src.pfRegion),
 			GameMode(src.GameMode),
 			CustomCommandLineData(src.CustomCommandLineData),
 			ExternalMatchmakerEventEndpoint(src.ExternalMatchmakerEventEndpoint)

--- a/PlayFabServerSDK/PlayFabSDK/source/PlayFabAdminDataModels.cpp
+++ b/PlayFabServerSDK/PlayFabSDK/source/PlayFabAdminDataModels.cpp
@@ -1807,7 +1807,7 @@ void GetMatchmakerGameInfoResult::writeJSON(PFStringJsonWriter& writer)
     
     if(BuildVersion.length() > 0) { writer.String("BuildVersion"); writer.String(BuildVersion.c_str()); }
     
-    if(Region.notNull()) { writer.String("Region"); writeRegionEnumJSON(Region, writer); }
+    if(pfRegion.notNull()) { writer.String("Region"); writeRegionEnumJSON(pfRegion, writer); }
     
     if(!Players.empty()) {
 	writer.String("Players");
@@ -1848,7 +1848,7 @@ bool GetMatchmakerGameInfoResult::readFromValue(const rapidjson::Value& obj)
 	if (BuildVersion_member != NULL && !BuildVersion_member->value.IsNull()) BuildVersion = BuildVersion_member->value.GetString();
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* Players_member = obj.FindMember("Players");
 	if (Players_member != NULL) {

--- a/PlayFabServerSDK/PlayFabSDK/source/PlayFabMatchmakerDataModels.cpp
+++ b/PlayFabServerSDK/PlayFabSDK/source/PlayFabMatchmakerDataModels.cpp
@@ -345,7 +345,7 @@ void StartGameRequest::writeJSON(PFStringJsonWriter& writer)
     
     writer.String("Build"); writer.String(Build.c_str());
     
-    writer.String("Region"); writeRegionEnumJSON(Region, writer);
+    writer.String("Region"); writeRegionEnumJSON(pfRegion, writer);
     
     writer.String("GameMode"); writer.String(GameMode.c_str());
     
@@ -364,7 +364,7 @@ bool StartGameRequest::readFromValue(const rapidjson::Value& obj)
 	if (Build_member != NULL && !Build_member->value.IsNull()) Build = Build_member->value.GetString();
     
     const Value::Member* Region_member = obj.FindMember("Region");
-	if (Region_member != NULL && !Region_member->value.IsNull()) Region = readRegionFromValue(Region_member->value);
+	if (Region_member != NULL && !Region_member->value.IsNull()) pfRegion = readRegionFromValue(Region_member->value);
     
     const Value::Member* GameMode_member = obj.FindMember("GameMode");
 	if (GameMode_member != NULL && !GameMode_member->value.IsNull()) GameMode = GameMode_member->value.GetString();

--- a/PlayFabServerSDK/PlayFabSDK/source/PlayFabResultHandler.cpp
+++ b/PlayFabServerSDK/PlayFabSDK/source/PlayFabResultHandler.cpp
@@ -38,7 +38,7 @@ bool PlayFabRequestHandler::DecodeRequest(int httpStatus, HttpRequest* request, 
 			outError.HttpCode = 408;
 			outError.ErrorCode = PlayFabErrorConnectionTimeout;
 			// For text returns, use the non-json response if possible, else default to no response
-			outError.ErrorName = outError.ErrorMessage = outError.HttpStatus = response.length() == 0 ? "Request Timeout or null response" : response;
+			outError.ErrorName = outError.ErrorMessage = outError.HttpStatus = response;
 			return false;
 		}
 		// TODO: what happens when the error is not in the enum?


### PR DESCRIPTION
Region (type) and Region (variable) have been adjusted so they don't have the same name - This is a requirement for android builds.
A bunch of calls to memcpy() and strncpy() have been replaced with sprintf(), which allows the Android build to compile.
