### PR TITLE
Improve ignore rules for built content in Cocos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 Debug.win32/
+bin/
+build/
 
 *.suo
 *.sdf


### PR DESCRIPTION
Ignoring more content that gets built by the `cocos run` tool so that we don't try to add generated files into source.
